### PR TITLE
Ackermann steering angle calculation fixups

### DIFF
--- a/ackermann_steering_controller/include/ackermann_steering_controller/odometry.h
+++ b/ackermann_steering_controller/include/ackermann_steering_controller/odometry.h
@@ -80,12 +80,12 @@ namespace ackermann_steering_controller
 
     /**
      * \brief Updates the odometry class with latest wheels position
-     * \param rear_wheel_pos  Rear wheel position [rad]
+     * \param rear_wheel_vel  Rear wheel velocity [m/s]
      * \param front_steer_pos Front Steer position [rad]
      * \param time      Current time
      * \return true if the odometry is actually updated
      */
-    bool update(double rear_wheel_pos, double front_steer_pos, const ros::Time &time);
+    bool update(double rear_wheel_vel, double front_steer_pos, const ros::Time &time);
 
     /**
      * \brief Updates the odometry class with latest velocity command
@@ -193,9 +193,6 @@ namespace ackermann_steering_controller
     /// Wheel kinematic parameters [m]:
     double wheel_separation_h_;
     double wheel_radius_;
-
-    /// Previous wheel position/state [rad]:
-    double rear_wheel_old_pos_;
 
     /// Rolling mean accumulators for the linar and angular velocities:
     size_t velocity_rolling_window_size_;

--- a/ackermann_steering_controller/src/ackermann_steering_controller.cpp
+++ b/ackermann_steering_controller/src/ackermann_steering_controller.cpp
@@ -265,15 +265,15 @@ namespace ackermann_steering_controller{
     }
     else
     {
-      double wheel_pos  = rear_wheel_joint_.getVelocity();
+      double rear_wheel_vel  = rear_wheel_joint_.getVelocity();
       double steer_pos = front_steer_joint_.getPosition();
 
-      if (std::isnan(wheel_pos) || std::isnan(steer_pos))
+      if (std::isnan(rear_wheel_vel) || std::isnan(steer_pos))
         return;
 
       // Estimate linear and angular velocity using joint information
       steer_pos = steer_pos * steer_pos_multiplier_;
-      odometry_.update(wheel_pos, steer_pos, time);
+      odometry_.update(rear_wheel_vel, steer_pos, time);
     }
 
     // Publish odometry message
@@ -339,7 +339,7 @@ namespace ackermann_steering_controller{
     rear_wheel_joint_.setCommand(wheel_vel);
     // The limit is set on angular velocity and not steering angle.
     // The controller isn't aware of any limitations of actual joints.
-    front_steer_joint_.setCommand(steering_ang); 
+    front_steer_joint_.setCommand(steering_ang);
 
   }
 

--- a/ackermann_steering_controller/src/odometry.cpp
+++ b/ackermann_steering_controller/src/odometry.cpp
@@ -75,21 +75,18 @@ namespace ackermann_steering_controller
   bool Odometry::update(double rear_wheel_pos, double front_steer_pos, const ros::Time &time)
   {
     /// Get current wheel joint positions:
-    const double rear_wheel_cur_pos = rear_wheel_pos * wheel_radius_;
+    const double rear_wheel_cur_pos = rear_wheel_pos * wheel_radius_ ;
 
     /// Estimate velocity of wheels using old and current position:
-    //const double left_wheel_est_vel  = left_wheel_cur_pos  - left_wheel_old_pos_;
-    //const double right_wheel_est_vel = right_wheel_cur_pos - right_wheel_old_pos_;
-
     const double rear_wheel_est_vel = rear_wheel_cur_pos - rear_wheel_old_pos_;
 
     /// Update old position with current:
     rear_wheel_old_pos_ = rear_wheel_cur_pos;
 
     /// Compute linear and angular diff:
-    const double linear  = rear_wheel_est_vel;//(right_wheel_est_vel + left_wheel_est_vel) * 0.5;
-    //const double angular = (right_wheel_est_vel - left_wheel_est_vel) / wheel_separation_w_;
-    const double angular = tan(front_steer_pos) * linear / wheel_separation_h_;
+    const double linear  = rear_wheel_est_vel;
+    
+    const double angular = linear / (wheel_separation_h_ / (front_steer_pos + 1e-10));
 
     /// Integrate odometry:
     integrate_fun_(linear, angular);

--- a/ackermann_steering_controller/src/odometry.cpp
+++ b/ackermann_steering_controller/src/odometry.cpp
@@ -57,7 +57,6 @@ namespace ackermann_steering_controller
   , angular_(0.0)
   , wheel_separation_h_(0.0)
   , wheel_radius_(0.0)
-  , rear_wheel_old_pos_(0.0)
   , velocity_rolling_window_size_(velocity_rolling_window_size)
   , linear_acc_(RollingWindow::window_size = velocity_rolling_window_size)
   , angular_acc_(RollingWindow::window_size = velocity_rolling_window_size)
@@ -72,21 +71,12 @@ namespace ackermann_steering_controller
     timestamp_ = time;
   }
 
-  bool Odometry::update(double rear_wheel_pos, double front_steer_pos, const ros::Time &time)
+  bool Odometry::update(double rear_wheel_vel, double front_steer_pos, const ros::Time &time)
   {
-    /// Get current wheel joint positions:
-    const double rear_wheel_cur_pos = rear_wheel_pos * wheel_radius_ ;
-
-    /// Estimate velocity of wheels using old and current position:
-    const double rear_wheel_est_vel = rear_wheel_cur_pos - rear_wheel_old_pos_;
-
-    /// Update old position with current:
-    rear_wheel_old_pos_ = rear_wheel_cur_pos;
-
     /// Compute linear and angular diff:
-    const double linear  = rear_wheel_est_vel;
-    
-    const double angular = linear / (wheel_separation_h_ / (front_steer_pos + 1e-10));
+    const double linear  = rear_wheel_vel;
+
+    const double angular = (linear * front_steer_pos) / wheel_separation_h_;
 
     /// Integrate odometry:
     integrate_fun_(linear, angular);


### PR DESCRIPTION
Looks like rear wheel velocity should be directly usable in Odometry::Update - it was passed in after the last commit, but was used as position was used previously, which looked suspicious.
With that being said, adding some UTs would probably make sense.